### PR TITLE
Typo in recursive call

### DIFF
--- a/translate_md.py
+++ b/translate_md.py
@@ -113,7 +113,7 @@ def restore_inline_code(token: SpanToken, inline_code_dict: dict):
 
     if hasattr(token, "children") and not isinstance(token, InlineCode) and token.children is not None:
         for child in token.children:
-            replace_inline_code(child, inline_code_dict)
+            restore_inline_code(child, inline_code_dict)
 
 
 def translate_block(


### PR DESCRIPTION
Fixes #6 

There was supposed to be a recursive call, but it was calling the wrong function.